### PR TITLE
Fixed issue where time was not being updated

### DIFF
--- a/config/controlConfig.yaml
+++ b/config/controlConfig.yaml
@@ -3,10 +3,10 @@ randomness:
 input_data:
     location: 'UK'
 time:
-    start: {year: 2011, month: 10, day: 1}
-    end:   {year: 2012, month: 10, day: 1}
-    step_size: 30.4375  # Days
-    num_years: 1
+    start: {year: 2011, month: 10, day: 15}
+    end:   {year: 2016, month: 10, day: 15}
+    step_size: 365.25  # Days
+    num_years: 5
 population:
     age_start: 0
     age_end: 100

--- a/minos/data_generation/generate_composite_vars.py
+++ b/minos/data_generation/generate_composite_vars.py
@@ -59,7 +59,10 @@ def generate_composite_housing_quality(data):
     data["housing_quality"] = np.select(conditions, values)
 
     # drop cols we don't need
-    data.drop(labels=['housing_sum', 'housing_complete'], axis=1, inplace=True)
+    data.drop(labels=['housing_sum', 'housing_complete', 'fridge_freezer', 'washing_machine', 'tumble_dryer',
+                      'dishwasher', 'microwave', 'heating'],
+              axis=1,
+              inplace=True)
 
     return data
 
@@ -92,6 +95,11 @@ def generate_hh_income(data):
 
     # Adjust hh income for inflation
     data = US_utils.inflation_adjustment(data, "hh_income")
+
+    # now drop the intermediates
+    data.drop(labels=['hh_rent', 'hh_mortgage', 'council_tax', 'outgoings', 'hh_netinc', 'oecd_equiv'],
+              axis=1,
+              inplace=True)
 
     return data
 

--- a/minos/modules/replenishment.py
+++ b/minos/modules/replenishment.py
@@ -3,7 +3,11 @@
 import pandas as pd
 
 
+# suppressing a warning that isn't a problem
+pd.options.mode.chained_assignment = None # default='warn' #supress SettingWithCopyWarning
+
 class Replenishment:
+
 
     @staticmethod
     def write_config(config):
@@ -19,6 +23,7 @@ class Replenishment:
             Config yaml tree for AngryMob with added items needed for this module to run.
         """
         return config
+
 
     @staticmethod
     def pre_setup(config, simulation):
@@ -40,6 +45,7 @@ class Replenishment:
         """
         # Does nothing here.
         return simulation
+
 
     def setup(self, builder):
         """ Method for initialising the depression module.
@@ -69,28 +75,20 @@ class Replenishment:
                         'job_sec',
                         'job_duration_m',
                         'job_duration_y',
-                        'heating',
                         'depression',
-                        'tumble_dryer',
                         'academic_year',
                         'depression_change',
-                        'microwave',
                         'hidp',
                         'birth_month',
                         'birth_year',
-                        'fridge_freezer',
-                        'dishwasher',
-                        'washing_machine',
                         'nobs',
                         'region',
                         'SF-12',
                         'hh_int_y',
-                        'oecd_equiv',
                         'hh_int_m',
-                        'council_tax',
-                        'hh_rent',
-                        'hh_mortgage',
-                        'hh_netinc'
+                        'Date',
+                        'housing_quality',
+                        'hh_income'
                         ]
 
         # Shorthand methods for readability.
@@ -101,9 +99,11 @@ class Replenishment:
         # Defines how this module initialises simulants when self.simulant_creater is called.
         builder.population.initializes_simulants(self.on_initialize_simulants,
                                                  creates_columns=view_columns)
-        # Register ageing and replenishment events on time_step.
+        # Register ageing, updating time and replenishment events on time_step.
         builder.event.register_listener('time_step', self.age_simulants)
+        #builder.event.register_listener('time_step', self.update_time)
         builder.event.register_listener('time_step', self.on_time_step, priority=0)
+
 
     def on_initialize_simulants(self, pop_data):
         """ function for loading new waves of simulants into the population from US data.
@@ -127,7 +127,7 @@ class Replenishment:
         if pop_data.user_data["sim_state"] == "setup":
             # Load in initial data frame.
             # Add entrance times and convert ages to floats for pd.timedelta to handle.
-            new_population = pd.read_csv(f"data/corrected_US/{self.current_year}_US_cohort.csv")
+            new_population = pd.read_csv(f"data/composite_US/{self.current_year}_US_cohort.csv")
             new_population.loc[new_population.index, "entrance_time"] = new_population["time"]
             new_population.loc[new_population.index, "age"] = new_population["age"].astype(float)
         elif pop_data.user_data["cohort_type"] == "replenishment":
@@ -154,6 +154,7 @@ class Replenishment:
         self.register(new_population[["entrance_time", "age"]])
         self.population_view.update(new_population)
 
+
     def on_time_step(self, event):
         """ On time step add new simulants to the module.
 
@@ -164,9 +165,13 @@ class Replenishment:
         """
         # Only add new cohorts on the october of each year when the data is taken.
         # If its october update the current year and load in new cohort data.
+        # Also update the time variable with the new year for everyone (dead people also)
+        pop = self.population_view.get(event.index, query='pidp > 0')
         if event.time.month == 10 and event.time.year == self.current_year + 1:
             self.current_year += 1
-            new_wave = pd.read_csv(f"data/corrected_US/{self.current_year}_US_cohort.csv")
+            pop['time'] += 1
+            self.population_view.update(pop)
+            new_wave = pd.read_csv(f"data/composite_US/{self.current_year}_US_cohort.csv")
         else:
             # otherwise dont load anyone in.
             new_wave = pd.DataFrame()
@@ -192,6 +197,7 @@ class Replenishment:
             # The method used can be changed in setup via builder.population.initializes_simulants.
             self.simulant_creater(cohort_size, population_configuration=new_cohort_config)
 
+
     def age_simulants(self, event):
         """ Age everyone by the length of the simulation time step in days
 
@@ -204,6 +210,21 @@ class Replenishment:
         population = self.population_view.get(event.index, query="alive == 'alive'")
         population['age'] += event.step_size / pd.Timedelta(days=365.25)
         self.population_view.update(population)
+
+
+    def update_time(self, event):
+        """ Update time variable by the length of the simulation time step in days
+
+        Parameters
+        ----------
+        event : builder.event
+            some time point at which to run the method.
+        """
+        # get alive people and add time in years to their age.
+        population = self.population_view.get(event.index, query="alive == 'alive'")
+        population['time'] += event.step_size / pd.Timedelta(days=365.25)
+        self.population_view.update(population)
+
 
     # Special methods for vivarium.
     @property

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -70,7 +70,7 @@ def run_pipeline(configuration_file, input_data_dir=None, persistent_data_dir=No
 
     # Print initial pop size.
     year_start = config.time.start.year
-    start_population_size = pd.read_csv(f"data/corrected_US/{year_start}_US_cohort.csv").shape[0]
+    start_population_size = pd.read_csv(f"data/composite_US/{year_start}_US_cohort.csv").shape[0]
     print('Start Population Size: {}'.format(start_population_size))
 
     # Output directory where all files from the run will be saved.


### PR DESCRIPTION
- Fixed issue with time not updating (was caused by starting on 1st October and first year being a leap year - this meant that 3/4 years the timestep would end on September 30th, where year was only updated in replenishment.py if event.time was in October)
- Removed intermediate variables that were used to generate some composite vars
- Fixed all references to corrected_US (by replacing them with composite_US)