### PR TITLE
93 logging take 2

### DIFF
--- a/minos/minosPipeline/RunPipeline.py
+++ b/minos/minosPipeline/RunPipeline.py
@@ -104,6 +104,10 @@ def validate_components(config_components, intervention):
         else:
             print("Warning! Component in config not found when running pipeline. Are you sure its in the minos/minosPipeline/RunPipeline.py script?")
 
+    # TODO: include some error handling for choosing interventions
+    # Can do this using assertions
+    # i.e. try { AssertThat(intervention is in list(<int1>, <int2>) ...
+    # or even cleverer if we can get the repr()'s from the intervention classes to automate this step
     if intervention in intervention_components_map.keys():
         # add intervention components.
         component_list.append(intervention_components_map[intervention])

--- a/minos/modules/education.py
+++ b/minos/modules/education.py
@@ -7,6 +7,7 @@ from minos.modules.base_module import Base
 pd.options.mode.chained_assignment = None # default='warn' #supress SettingWithCopyWarning
 import matplotlib.pyplot as plt
 from seaborn import catplot
+import logging
 
 class Education(Base):
 
@@ -69,6 +70,9 @@ class Education(Base):
         event : vivarium.population.PopulationEvent
             The `event` that triggered the function call.
         """
+
+        logging.info("EDUCATION")
+
         self.year = event.time.year
 
         # Level 2 is equivalent to GCSE level, which everyone should have achieved by the age of 17

--- a/minos/modules/housing.py
+++ b/minos/modules/housing.py
@@ -10,6 +10,7 @@ from minos.modules import r_utils
 from minos.modules.base_module import Base
 import matplotlib.pyplot as plt
 from seaborn import catplot
+import logging
 from datetime import datetime as dt
 
 class Housing(Base):
@@ -82,6 +83,9 @@ class Housing(Base):
         event : vivarium.population.PopulationEvent
             The event time_step that called this function.
         """
+
+        logging.info("HOUSING QUALITY")
+
         # Construct transition probability distributions.
         # Draw individuals next states randomly from this distribution.
         # Adjust other variables according to changes in state. E.g. a birth would increase child counter by one.

--- a/minos/modules/housing.py
+++ b/minos/modules/housing.py
@@ -73,7 +73,7 @@ class Housing(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
+        builder.event.register_listener("time_step", self.on_time_step, priority=5)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/income.py
+++ b/minos/modules/income.py
@@ -9,6 +9,7 @@ import minos.modules.r_utils as r_utils
 from minos.modules.base_module import Base
 import matplotlib.pyplot as plt
 from seaborn import histplot
+import logging
 
 
 class Income(Base):
@@ -104,6 +105,9 @@ class Income(Base):
         event : vivarium.population.PopulationEvent
             The event time_step that called this function.
         """
+
+        logging.info("INCOME")
+
         # Get living people to update their income
         pop = self.population_view.get(event.index, query="alive =='alive'")
         self.year = event.time.year

--- a/minos/modules/intervention.py
+++ b/minos/modules/intervention.py
@@ -91,7 +91,7 @@ class hhIncomeIntervention():
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        builder.event.register_listener("time_step", self.on_time_step, priority=4)
 
     def on_initialize_simulants(self, pop_data):
         pop_update = pd.DataFrame({'income_boosted': False,
@@ -168,7 +168,7 @@ class hhIncomeChildUplift(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        builder.event.register_listener("time_step", self.on_time_step, priority=4)
 
     def on_initialize_simulants(self, pop_data):
         pop_update = pd.DataFrame({'income_boosted': False,
@@ -243,7 +243,7 @@ class hhIncomePovertyLineChildUplift(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        builder.event.register_listener("time_step", self.on_time_step, priority=4)
 
     def on_initialize_simulants(self, pop_data):
         pop_update = pd.DataFrame({'income_boosted': False, # who boosted?
@@ -320,7 +320,7 @@ class livingWageIntervention(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        builder.event.register_listener("time_step", self.on_time_step, priority=4)
 
 
     def on_initialize_simulants(self, pop_data):
@@ -431,7 +431,7 @@ class energyDownlift(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        builder.event.register_listener("time_step", self.on_time_step, priority=4)
 
 
     def on_initialize_simulants(self, pop_data):

--- a/minos/modules/labour.py
+++ b/minos/modules/labour.py
@@ -11,6 +11,7 @@ import random
 from minos.modules.base_module import Base
 import matplotlib.pyplot as plt
 from seaborn import catplot
+import logging
 
 class Labour(Base):
     # Special methods used by vivarium.
@@ -84,6 +85,9 @@ class Labour(Base):
         event : vivarium.population.PopulationEvent
             The event time_step that called this function.
         """
+
+        logging.info("LABOUR STATE")
+
         # Construct transition probability distributions.
         # Draw individuals next states randomly from this distribution.
         # Adjust other variables according to changes in state. E.g. a birth would increase child counter by one.

--- a/minos/modules/labour.py
+++ b/minos/modules/labour.py
@@ -75,7 +75,7 @@ class Labour(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        builder.event.register_listener("time_step", self.on_time_step, priority=5)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/loneliness.py
+++ b/minos/modules/loneliness.py
@@ -70,7 +70,7 @@ class Loneliness(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
+        builder.event.register_listener("time_step", self.on_time_step, priority=5)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/loneliness.py
+++ b/minos/modules/loneliness.py
@@ -6,6 +6,7 @@ from minos.modules import r_utils
 from minos.modules.base_module import Base
 import matplotlib.pyplot as plt
 from seaborn import catplot
+import logging
 
 
 class Loneliness(Base):
@@ -105,6 +106,9 @@ class Loneliness(Base):
         Returns
         -------
         """
+
+        logging.info("LONELINESS")
+
         # load transition model based on year.
         if self.year < 2018:
             year = 2018

--- a/minos/modules/mental_wellbeing.py
+++ b/minos/modules/mental_wellbeing.py
@@ -10,6 +10,7 @@ import minos.modules.r_utils as r_utils
 from minos.modules.base_module import Base
 from seaborn import histplot
 import matplotlib.pyplot as plt
+import logging
 
 
 class MWB(Base):
@@ -108,6 +109,8 @@ class MWB(Base):
         event : vivarium.population.PopulationEvent
             The event time_step that called this function.
         """
+
+        logging.info("MENTAL WELLBEING (SF12 MCS)")
 
         self.year = event.time.year
 

--- a/minos/modules/mortality.py
+++ b/minos/modules/mortality.py
@@ -9,6 +9,7 @@ This module contains tools modeling all cause mortality.
 import pandas as pd
 from pathlib import Path
 import random
+import logging
 
 # Required rate conversion and rate table creation functions.
 from vivarium.framework.utilities import rate_to_probability
@@ -130,6 +131,9 @@ class Mortality(Base):
         event : vivarium.population.PopulationEvent
             The event time_step that called this function.
         """
+
+        logging.info("MORTALITY")
+
         # Get everyone who is alive and calculate their rate of death.
         pop = self.population_view.get(event.index, query="alive =='alive' and sex != 'nan'")
         # Convert these rates to probabilities of death or not death.

--- a/minos/modules/neighbourhood.py
+++ b/minos/modules/neighbourhood.py
@@ -66,7 +66,7 @@ class Neighbourhood(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
+        builder.event.register_listener("time_step", self.on_time_step, priority=5)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/neighbourhood.py
+++ b/minos/modules/neighbourhood.py
@@ -9,6 +9,7 @@ import minos.modules.r_utils as r_utils
 from minos.modules.base_module import Base
 import matplotlib.pyplot as plt
 from seaborn import catplot
+import logging
 
 class Neighbourhood(Base):
 
@@ -75,6 +76,9 @@ class Neighbourhood(Base):
         event : vivarium.population.PopulationEvent
             The event time_step that called this function.
         """
+
+        logging.info("NEIGHBOURHOOD SAFETY")
+
         # Get living people to update their neighbourhood
         pop = self.population_view.get(event.index, query="alive =='alive'")
         self.year = event.time.year

--- a/minos/modules/nutrition.py
+++ b/minos/modules/nutrition.py
@@ -65,7 +65,7 @@ class Nutrition(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
+        builder.event.register_listener("time_step", self.on_time_step, priority=5)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/nutrition.py
+++ b/minos/modules/nutrition.py
@@ -6,6 +6,7 @@ Calculation of weekly consumption of fruit and veg.
 import pandas as pd
 import minos.modules.r_utils as r_utils
 from minos.modules.base_module import Base
+import logging
 
 class Nutrition(Base):
 
@@ -74,6 +75,9 @@ class Nutrition(Base):
         event : vivarium.population.PopulationEvent
             The event time_step that called this function.
         """
+
+        logging.info("NUTRITION QUALITY")
+
         self.year = event.time.year
 
         # Get living people to update their income

--- a/minos/modules/replenishment.py
+++ b/minos/modules/replenishment.py
@@ -3,6 +3,7 @@ File for adding new cohorts from Understanding Society data to the population
 """
 
 import pandas as pd
+import logging
 from minos.modules.base_module import Base
 
 
@@ -157,6 +158,8 @@ class Replenishment(Base):
             The `event` that triggered the function call.
         """
 
+        logging.info("REPLENISHMENT")
+
         # Only add new cohorts on the october of each year when the data is taken.
         # If its october update the current year and load in new cohort data.
         # Also update the time variable with the new year for everyone (dead people also)
@@ -205,6 +208,8 @@ class Replenishment(Base):
             # Create simulants and add them to the population data frame.
             # The method used can be changed in setup via builder.population.initializes_simulants.
             self.simulant_creater(cohort_size, population_configuration=new_cohort_config)
+            # logging
+            logging.info(f"\tTotal new 16 year olds added to the model: {cohort_size}")
 
     def age_simulants(self, event):
         """ Age everyone by the length of the simulation time step in days

--- a/minos/modules/tobacco.py
+++ b/minos/modules/tobacco.py
@@ -9,6 +9,7 @@ import minos.modules.r_utils as r_utils
 from minos.modules.base_module import Base
 import matplotlib.pyplot as plt
 from seaborn import histplot
+import logging
 
 class Tobacco(Base):
 
@@ -83,6 +84,9 @@ class Tobacco(Base):
         event : vivarium.population.PopulationEvent
             The event time_step that called this function.
         """
+
+        logging.info("TOBACCO")
+
         # Get living people to update their tobacco
         pop = self.population_view.get(event.index, query="alive =='alive'")
         self.year = event.time.year

--- a/minos/modules/tobacco.py
+++ b/minos/modules/tobacco.py
@@ -74,7 +74,7 @@ class Tobacco(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
+        builder.event.register_listener("time_step", self.on_time_step, priority=5)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.


### PR DESCRIPTION
Had a lot of this stuff in a branch from last November but forgot to add it in. Didn't want to deal with any issues from merge conflicts with old scripts -> new scripts so I created a new branch off development and added it all in. 

Changes:
- Logging for each module so we know exactly which order the modules run.
- Logging for each intervention on_time_step(), with a couple of pieces of information:
    - Number affected
    - Total value added/removed from system
    - Mean value added/removed
    - Occasionally more info such as London vs notLondon in case of Living Wage
- Fixed priority of modules, so that it goes replenishment, mortality, income, intervention, PATHWAYS, SF12 MCS