### PR TITLE
371 repl households

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ tests/data/*
 .Rproj.user
 Minos.Rproj
 .RData
-.Rhistory
 
 # Knitted R notebook files
 minos/validation/*.html
@@ -100,3 +99,15 @@ plots/*
 # HR 21/12/22 Windows utils stuff to ignore
 minos/windowsutils/output/
 minos/windowsutils/output/*
+
+# LA 30/1/24
+# spatial data files
+persistent_data/spatial_data/*
+# testing notebooks
+minos/testing/*.Rmd
+# image files creates by RNotebooks (we can use the html file generated instead of the individual files)
+minos/validation/*_files/
+minos/testing/*_files/
+# python notebooks for testing
+notebooks/equivalent_income_test.ipynb
+notebooks/testing_scottish_sample.ipynb

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,9 @@ dependencies: # Added pip and python at top to avoid conda giving grumpy warning
   - r-ggridges
   - r-gghighlight
   - r-randomForest
+  - r-parellelly
+  - r-doParallel
+  - r-caret
   - pandoc
   - sphinx
   - myst-parser

--- a/minos/data_generation/generate_repl_pop.py
+++ b/minos/data_generation/generate_repl_pop.py
@@ -46,36 +46,36 @@ def expand_repl(US_wave, region):
         Expanded dataset (copy of original 16-year-olds for each year from 2018 to 2070) reweighted by sex
     """
 
-    # just select the 16 and 17-year-olds in 2018 to be copied and reweighted (replace age as 16)
-    repl_wave = US_wave[(US_wave['age'].isin([16, 17]))]
-    repl_wave['age'] = 16
-    # We can't have 16-year-olds with higher educ than level 2 (these are all from 17 yos) so replace these with 2
-    repl_wave['education_state'][repl_wave['education_state'] > 2] = 2
-
-    # # get max hidp value so we can add new households with unique hidp
-    # max_hidp = US_wave['hidp'].max()
-    #
-    # # Find households with a 16 or 17 year old to add as replenishing
-    # repl_wave_hidps = US_wave[(US_wave['age'].isin([16, 17]))]['hidp']
-    # repl_hhs = US_wave[US_wave['hidp'].isin(repl_wave_hidps)]
-    # # Change age of 17 year olds to 16 year olds (we take both ages for replenishment as the 16 year old sample is very small)
-    # repl_hhs['age'][repl_hhs['age'] == 17] = 16
+    # # just select the 16 and 17-year-olds in 2018 to be copied and reweighted (replace age as 16)
+    # repl_wave = US_wave[(US_wave['age'].isin([16, 17]))]
+    # repl_wave['age'] = 16
     # # We can't have 16-year-olds with higher educ than level 2 (these are all from 17 yos) so replace these with 2
-    # repl_hhs['education_state'][(repl_hhs['age'] == 16) & (repl_hhs['education_state'] > 2)] = 2
-    #
-    # # Final step now we are adding complete households. We need to give the non 16 year olds a flag that distinguishes
-    # # them from other simulants. We will do this by setting the weight of these individuals to 0.
-    # # This means these individuals will transition throughout the model as normal, but be ignored in the outputs as
-    # # we almost exclusively use weighed statistics. One possible solution to non-weighted sums in outputs is to remove
-    # # all 0 weight individuals at the same time as removing living people
-    # # repl_hhs['alive'][repl_hhs['age'] != 16] = 'ghost'
-    # repl_hhs['weight'][repl_hhs['age'] != 16] = 0
+    # repl_wave['education_state'][repl_wave['education_state'] > 2] = 2
+
+    # get max hidp value so we can add new households with unique hidp
+    max_hidp = US_wave['hidp'].max()
+
+    # Find households with a 16 or 17 year old to add as replenishing
+    repl_wave_hidps = US_wave[(US_wave['age'].isin([16, 17]))]['hidp']
+    repl_hhs = US_wave[US_wave['hidp'].isin(repl_wave_hidps)]
+    # Change age of 17 year olds to 16 year olds (we take both ages for replenishment as the 16 year old sample is very small)
+    repl_hhs['age'][repl_hhs['age'] == 17] = 16
+    # We can't have 16-year-olds with higher educ than level 2 (these are all from 17 yos) so replace these with 2
+    repl_hhs['education_state'][(repl_hhs['age'] == 16) & (repl_hhs['education_state'] > 2)] = 2
+
+    # Final step now we are adding complete households. We need to give the non 16 year olds a flag that distinguishes
+    # them from other simulants. We will do this by setting the weight of these individuals to 0.
+    # This means these individuals will transition throughout the model as normal, but be ignored in the outputs as
+    # we almost exclusively use weighed statistics. One possible solution to non-weighted sums in outputs is to remove
+    # all 0 weight individuals at the same time as removing living people
+    # repl_hhs['alive'][repl_hhs['age'] != 16] = 'ghost'
+    repl_hhs['weight'][repl_hhs['age'] != 16] = 0
 
     expanded_repl = pd.DataFrame()
     # first copy original dataset for every year from 2018 (current) - 2070
     for year in range(2014, 2071, 1):
         # first get copy of 2018 16 (and 17) -year-olds
-        new_repl = repl_wave.copy()
+        new_repl = repl_hhs.copy()
         # change time (for entry year)
         new_repl['time'] = year
         # change birth year
@@ -116,17 +116,17 @@ def expand_repl(US_wave, region):
     # reset index for the predict_education step
     expanded_repl.reset_index(drop=True, inplace=True)
 
-    # # Final step is to assign new unique hidps to the replenishing populations
-    # # expanded_repl['hidp'] = expanded_repl['hidp'] + max_hidp + expanded_repl['time']
-    # # Iterate over each year
-    # for year in expanded_repl['time'].unique():
-    #     # Filter the dataframe for the current year
-    #     df_year = expanded_repl[expanded_repl['time'] == year]
-    #
-    #     # Group by original 'hidp' and assign new 'hidp' values
-    #     for _, group in df_year.groupby('hidp'):
-    #         max_hidp += 1  # Increment the max_hidp for a new unique hidp
-    #         expanded_repl.loc[group.index, 'hidp'] = max_hidp  # Assign new hidp
+    # Final step is to assign new unique hidps to the replenishing populations
+    # expanded_repl['hidp'] = expanded_repl['hidp'] + max_hidp + expanded_repl['time']
+    # Iterate over each year
+    for year in expanded_repl['time'].unique():
+        # Filter the dataframe for the current year
+        df_year = expanded_repl[expanded_repl['time'] == year]
+
+        # Group by original 'hidp' and assign new 'hidp' values
+        for _, group in df_year.groupby('hidp'):
+            max_hidp += 1  # Increment the max_hidp for a new unique hidp
+            expanded_repl.loc[group.index, 'hidp'] = max_hidp  # Assign new hidp
 
     return expanded_repl
 

--- a/minos/data_generation/generate_repl_pop.py
+++ b/minos/data_generation/generate_repl_pop.py
@@ -52,6 +52,25 @@ def expand_repl(US_wave, region):
     # We can't have 16-year-olds with higher educ than level 2 (these are all from 17 yos) so replace these with 2
     repl_wave['education_state'][repl_wave['education_state'] > 2] = 2
 
+    # # get max hidp value so we can add new households with unique hidp
+    # max_hidp = US_wave['hidp'].max()
+    #
+    # # Find households with a 16 or 17 year old to add as replenishing
+    # repl_wave_hidps = US_wave[(US_wave['age'].isin([16, 17]))]['hidp']
+    # repl_hhs = US_wave[US_wave['hidp'].isin(repl_wave_hidps)]
+    # # Change age of 17 year olds to 16 year olds (we take both ages for replenishment as the 16 year old sample is very small)
+    # repl_hhs['age'][repl_hhs['age'] == 17] = 16
+    # # We can't have 16-year-olds with higher educ than level 2 (these are all from 17 yos) so replace these with 2
+    # repl_hhs['education_state'][(repl_hhs['age'] == 16) & (repl_hhs['education_state'] > 2)] = 2
+    #
+    # # Final step now we are adding complete households. We need to give the non 16 year olds a flag that distinguishes
+    # # them from other simulants. We will do this by setting the weight of these individuals to 0.
+    # # This means these individuals will transition throughout the model as normal, but be ignored in the outputs as
+    # # we almost exclusively use weighed statistics. One possible solution to non-weighted sums in outputs is to remove
+    # # all 0 weight individuals at the same time as removing living people
+    # # repl_hhs['alive'][repl_hhs['age'] != 16] = 'ghost'
+    # repl_hhs['weight'][repl_hhs['age'] != 16] = 0
+
     expanded_repl = pd.DataFrame()
     # first copy original dataset for every year from 2018 (current) - 2070
     for year in range(2014, 2071, 1):
@@ -96,6 +115,18 @@ def expand_repl(US_wave, region):
 
     # reset index for the predict_education step
     expanded_repl.reset_index(drop=True, inplace=True)
+
+    # # Final step is to assign new unique hidps to the replenishing populations
+    # # expanded_repl['hidp'] = expanded_repl['hidp'] + max_hidp + expanded_repl['time']
+    # # Iterate over each year
+    # for year in expanded_repl['time'].unique():
+    #     # Filter the dataframe for the current year
+    #     df_year = expanded_repl[expanded_repl['time'] == year]
+    #
+    #     # Group by original 'hidp' and assign new 'hidp' values
+    #     for _, group in df_year.groupby('hidp'):
+    #         max_hidp += 1  # Increment the max_hidp for a new unique hidp
+    #         expanded_repl.loc[group.index, 'hidp'] = max_hidp  # Assign new hidp
 
     return expanded_repl
 

--- a/minos/transitions/transition_model_functions.R
+++ b/minos/transitions/transition_model_functions.R
@@ -5,6 +5,9 @@ require(pscl)
 require(bestNormalize)
 require(lme4)
 require(randomForest)
+require(caret)
+require(doParallel)
+require(parallelly)
 
 ################ Model Specific Functions ################
 
@@ -343,9 +346,30 @@ estimate_RandomForest <- function(data, formula, depend) {
   
   print('Beginning estimation of the RandomForest model. This can take a while, its probably not frozen...')
   
+  numCores <- availableCores() / 2
+  
+  registerDoParallel(cores = numCores)
+  
   data <- replace.missing(data)
   data <- drop_na(data)
-  model <- randomForest(formula, data = data, ntree = 100, do.trace = TRUE)
   
-  return(model)
+  print("Training RandomForest with parallel processing...")
+  # Train RandomForest with parallel processing
+  fitControl <- trainControl(method = "cv", number = 5, allowParallel = TRUE, verboseIter = TRUE)
+  set.seed(123)
+  
+  # Adjusting the model parameters to use fewer trees and limit depth
+  rfModel <- train(formula, data = data, 
+                   method = "rf",
+                   trControl = fitControl,
+                   tuneGrid = expand.grid(mtry = 3), 
+                   ntree = 100)  # RF Parameters
+  
+  # expand.grid(mtry = ncol(data) / 3)
+  
+  
+  
+  #model <- randomForest(formula, data = data, ntree = 100, do.trace = TRUE)
+  
+  return(rfModel)
 }

--- a/minos/transitions/transition_model_functions.R
+++ b/minos/transitions/transition_model_functions.R
@@ -345,7 +345,7 @@ estimate_RandomForest <- function(data, formula, depend) {
   
   data <- replace.missing(data)
   data <- drop_na(data)
-  model <- randomForest(formula, data = data, ntree = 100)
+  model <- randomForest(formula, data = data, ntree = 100, do.trace = TRUE)
   
   return(model)
 }

--- a/minos/utils_validation_vis.R
+++ b/minos/utils_validation_vis.R
@@ -384,11 +384,11 @@ snapshot_OP_plots <- function(raw, cv, var, target.years) {
 ## Yearly box plots for multiple years, compared between raw and cv runs
 multi_year_boxplots <- function(raw, cv, var) {
   raw.var <- raw %>%
-    dplyr::select(pidp, time, all_of(var))
+    dplyr::select(time, all_of(var))
   raw.var$source <- 'raw'
   
   cv.var <- cv %>%
-    dplyr::select(pidp, time, all_of(var))
+    dplyr::select(time, all_of(var))
   cv.var$source <- 'cross-validation'
   
   combined <- rbind(raw.var, cv.var)

--- a/minos/validation/cross_validation_default.Rmd
+++ b/minos/validation/cross_validation_default.Rmd
@@ -350,6 +350,32 @@ cv_ordinal_plots(pivoted.df = ethnic.piv.nowhite,
 rm(ethnic.pivoted, ethnic.piv.nowhite)
 ```
 
+## nkids Household
+
+```{r}
+cv.mean.plots(cv1, cv2, cv3, cv4, cv5, raw, 'nkids')
+multi_year_boxplots(raw, cv, 'nkids')
+q_q_comparison(raw, cv, 'nkids')
+```
+
+## nkids Max
+
+```{r}
+raw.nkids_max <- raw %>%
+  dplyr::select(pidp, time, nkids) %>%
+  group_by(time) %>%
+  summarise(max_nkids = max(nkids)) %>%
+  mutate(source = 'final_US')
+
+cv.nkids_max <- cv %>%
+  dplyr::select(pidp, time, nkids) %>%
+  group_by(time) %>%
+  summarise(max_nkids = max(nkids)) %>%
+  mutate(source = 'baseline_output')
+
+multi_year_boxplots(raw.nkids_max, cv.nkids_max, 'max_nkids')
+```
+
 ## Parity
 
 ```{r}

--- a/minos/validation/handovers.Rmd
+++ b/minos/validation/handovers.Rmd
@@ -684,6 +684,57 @@ cv_ordinal_plots(pivoted.df = pivoted,
 # rm(raw.s, base.s, spag)
 ```
 
+## nkids Household
+
+```{r}
+handover_boxplots(raw.dat, base.dat, 'nkids')
+handover_lineplots(raw.dat, base.dat, 'nkids')
+```
+
+```{r}
+raw.s <- raw.dat %>%
+  select(pidp, age, time, nkids)
+base.s <- base.dat %>%
+  select(pidp, age, time, nkids)
+
+spag <- rbind(raw.s, base.s)
+
+spaghetti_plot(spag, 'nkids',
+               save = shall.we.save,
+               save.path = save.path)
+
+rm(raw.s, base.s, spag)
+```
+
+## nkids Max
+
+```{r}
+# first figure out how to plot final_US
+# start with hh_income
+raw.nkids_max <- raw.dat %>%
+  dplyr::select(pidp, time, nkids) %>%
+  group_by(time) %>%
+  summarise(max_nkids = max(nkids)) %>%
+  mutate(source = 'final_US')
+
+base.nkids_max <- base.dat %>%
+  dplyr::select(pidp, time, nkids) %>%
+  group_by(time) %>%
+  summarise(max_nkids = max(nkids)) %>%
+  mutate(source = 'baseline_output')
+
+# merge before plot
+max_nkids <- rbind(raw.nkids_max, base.nkids_max)
+
+# Now plot
+ggplot(data = max_nkids, mapping = aes(x = time, y = max_nkids, group = source, colour = source)) +
+  geom_line() +
+  geom_vline(xintercept=start.year, linetype='dotted') +
+  labs(title = 'Max nkids', subtitle = 'Full Sample') +
+  xlab('Year') +
+  ylab('Average')
+```
+
 ## Parity
 
 ```{r}


### PR DESCRIPTION
This PR includes 2 changes:

1. Household Replenishment
2. Multiprocessing of RandomForest model

### Household Replenishment
Close #371 

Changed replenishment to add full households alongside the 16 year old individuals previously added, and scramble the hidp's to ensure unique households. This resolves the problem of households being artificially inflated by replenishing populations and causing problems with household related variables (e.g. hh_income, nkids). This is a bit of a partial fix, as it solves these problems but is not yet a perfect solution (we are not handling 16 year olds moving out of the family home, or moving away for education etc.).

### RandomForest Multiprocessing

The RF model fit step takes a very long time in comparison with other models. I have added multiprocessing to this step, but some testing is required as this has caused the RAM demand to increase quite a lot. If @RobertClay can run with 8GB RAM then I think these parameters are safe. If not, then multiprocessing here doesn't make sense as some RF parameters have already been tuned to limit RAM usage and any further changes would most likely hurt model performance.
