### PR TITLE
Setting module priorities once via RunPipeline and dict attached to s…

### DIFF
--- a/minos/RateTables/FertilityRateTable.py
+++ b/minos/RateTables/FertilityRateTable.py
@@ -327,7 +327,7 @@ class FertilityRateTable(BaseHandler):
             self.parity_max = self.configuration["parity_max"]
         else:
             self.parity_max = PARITY_MAX_DEFAULT
-        print("Max. parity:", self.parity_max)
+        # print("Max. parity:", self.parity_max)
         self._parity_added = False
 
     def _build(self):

--- a/minos/modules/S7EquivalentIncome.py
+++ b/minos/modules/S7EquivalentIncome.py
@@ -77,7 +77,8 @@ class S7EquivalentIncome(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=7)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """ Predicts the hh_income for the next timestep.

--- a/minos/modules/S7Housing.py
+++ b/minos/modules/S7Housing.py
@@ -72,7 +72,8 @@ class S7Housing(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/S7Labour.py
+++ b/minos/modules/S7Labour.py
@@ -72,7 +72,8 @@ class S7Labour(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/S7MentalHealth.py
+++ b/minos/modules/S7MentalHealth.py
@@ -73,7 +73,8 @@ class S7MentalHealth(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/S7Neighbourhood.py
+++ b/minos/modules/S7Neighbourhood.py
@@ -66,7 +66,8 @@ class S7Neighbourhood(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/S7PhysicalHealth.py
+++ b/minos/modules/S7PhysicalHealth.py
@@ -74,7 +74,8 @@ class S7PhysicalHealth(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/add_new_birth_cohorts.py
+++ b/minos/modules/add_new_birth_cohorts.py
@@ -94,7 +94,8 @@ class FertilityAgeSpecificRates(Base):
                                                  creates_columns=['last_birth_time', 'parent_id'],
                                                  requires_columns=['sex'])
         # Add listener event to check who has given birth on each time step using the on_time_step function below.
-        builder.event.register_listener('time_step', self.on_time_step, priority=2)
+        # builder.event.register_listener('time_step', self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         """ Adds the required columns for the module to run to the population data frame.
@@ -203,8 +204,8 @@ class nkidsFertilityAgeSpecificRates(Base):
     """
     A simulant-specific model for fertility and pregnancies.
     """
-    @staticmethod
-    def pre_setup(config, simulation):
+    # @staticmethod
+    def pre_setup(self, config, simulation):
         """ Load in anything required for the module to run.
 
         Parameters
@@ -275,8 +276,8 @@ class nkidsFertilityAgeSpecificRates(Base):
         self.population_view = builder.population.get_view(view_columns + columns_created)
 
         # Add listener event to check who has given birth on each time step using the on_time_step function below.
-        builder.event.register_listener('time_step', self.on_time_step, priority=2)
-
+        # builder.event.register_listener('time_step', self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         """ Adds the required columns for the module to run to the population data frame.

--- a/minos/modules/ageing.py
+++ b/minos/modules/ageing.py
@@ -31,8 +31,8 @@ class Ageing(Base):
         self.population_view = builder.population.get_view(view_columns)  # view simulants
 
         # Register ageing, updating time and replenishment events on time_step.
-        builder.event.register_listener('time_step', self.on_time_step, priority=2)
-
+        # builder.event.register_listener('time_step', self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """ Age everyone by the length of the simulation time step in days

--- a/minos/modules/alcohol.py
+++ b/minos/modules/alcohol.py
@@ -71,7 +71,8 @@ class Alcohol(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/base_module.py
+++ b/minos/modules/base_module.py
@@ -10,7 +10,17 @@ from scipy.special import ndtri  # very fast standard normal sampler.
 from minos.data_generation.US_utils import load_multiple_data
 import pandas as pd
 
+PRIORITY_DEFAULT = 10
+
+
 class Base():
+
+    @property
+    def name(self):
+        return "base"
+
+    def __repr__(self):
+        return "Base()"
 
     def pre_setup(self, config, simulation):
         """ Load in anything required for the module to run into the config and simulation object.
@@ -40,8 +50,20 @@ class Base():
         # mode
         self.cross_validation = config.cross_validation
 
+        # # Grab module priority
+        # self.priority = simulation.component_priority_map.get(self.__repr__(), PRIORITY_DEFAULT)
+        # print("Priority for {} set to {}".format(self.__repr__(), self.priority))
+
         return simulation
 
+    def setup(self, builder):
+        component_priority_map = builder.data.load("component_priority_map")
+        self.priority = component_priority_map.get(self.__repr__(), PRIORITY_DEFAULT)
+        # print("Priority for {} set to {}".format(self.__repr__(), self.priority))
+        builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+
+    def on_time_step(self, event):
+        pass
 
     def on_initialize_simulants(self, pop_data):
         """  Initiate columns for mortality when new simulants are added. By default adds no columns.

--- a/minos/modules/education.py
+++ b/minos/modules/education.py
@@ -55,7 +55,8 @@ class Education(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=5)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """ On time step check handle various education changes for people aged 16-30.

--- a/minos/modules/financial_situation.py
+++ b/minos/modules/financial_situation.py
@@ -74,7 +74,8 @@ class financialSituation(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """ Predicts the hh_income for the next timestep.

--- a/minos/modules/heating.py
+++ b/minos/modules/heating.py
@@ -72,8 +72,8 @@ class Heating(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
-
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/hourly_wage.py
+++ b/minos/modules/hourly_wage.py
@@ -81,7 +81,8 @@ class HourlyWage(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         # just load this once.
         #self.gee_transition_model = r_utils.load_transitions(f"hh_income/gee_yj/hh_income_GEE_YJ", self.rpy2Modules,

--- a/minos/modules/housing.py
+++ b/minos/modules/housing.py
@@ -79,7 +79,8 @@ class Housing(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/housing_tenure.py
+++ b/minos/modules/housing_tenure.py
@@ -75,7 +75,8 @@ class HousingTenure(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=5)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/income.py
+++ b/minos/modules/income.py
@@ -77,7 +77,8 @@ class Income(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         """  Initiate columns for hh_income when new simulants are added.
@@ -250,7 +251,8 @@ class geeIncome(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         # just load this once.
         self.gee_transition_model = r_utils.load_transitions(f"hh_income/gee/hh_income_GEE", self.rpy2Modules,
@@ -434,7 +436,8 @@ class geeYJIncome(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         # just load this once.
         #self.gee_transition_model = r_utils.load_transitions(f"hh_income/gee_yj/hh_income_GEE_YJ", self.rpy2Modules,
@@ -624,7 +627,8 @@ class lmmYJIncome(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         # just load this once.
         #self.gee_transition_model = r_utils.load_transitions(f"hh_income/gee_yj/hh_income_GEE_YJ", self.rpy2Modules,
@@ -799,7 +803,8 @@ class lmmDiffIncome(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         # just load this once.
         #self.gee_transition_model = r_utils.load_transitions(f"hh_income/gee_yj/hh_income_GEE_YJ", self.rpy2Modules,

--- a/minos/modules/intervention.py
+++ b/minos/modules/intervention.py
@@ -91,7 +91,8 @@ class hhIncomeIntervention():
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         pop_update = pd.DataFrame({'income_boosted': False,
@@ -170,7 +171,8 @@ class hhIncomeChildUplift(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         pop_update = pd.DataFrame({'income_boosted': False,
@@ -247,7 +249,8 @@ class hhIncomePovertyLineChildUplift(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         pop_update = pd.DataFrame({'income_boosted': False, # who boosted?
@@ -326,8 +329,8 @@ class livingWageIntervention(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
-
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         """
@@ -445,8 +448,8 @@ class energyDownlift(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
-
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         pop_update = pd.DataFrame({'income_boosted': False,  # who boosted?
@@ -529,8 +532,8 @@ class energyDownliftNoSupport(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=4)
-
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         pop_update = pd.DataFrame({'income_boosted': False,  # who boosted?

--- a/minos/modules/job_hours.py
+++ b/minos/modules/job_hours.py
@@ -80,7 +80,8 @@ class JobHours(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         # just load this once.
         #self.gee_transition_model = r_utils.load_transitions(f"hh_income/gee_yj/hh_income_GEE_YJ", self.rpy2Modules,

--- a/minos/modules/job_sec.py
+++ b/minos/modules/job_sec.py
@@ -66,7 +66,8 @@ class JobSec(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=3)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/labour.py
+++ b/minos/modules/labour.py
@@ -79,7 +79,8 @@ class Labour(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/loneliness.py
+++ b/minos/modules/loneliness.py
@@ -73,7 +73,8 @@ class Loneliness(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/mental_wellbeing.py
+++ b/minos/modules/mental_wellbeing.py
@@ -80,8 +80,8 @@ class MWB(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=7)
-
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         """  Initiate columns for SF_12 when new simulants are added.
@@ -247,7 +247,8 @@ class geeMWB(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=7)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         self.max_sf12 = None
         #only need to load this once for now.
@@ -376,7 +377,8 @@ class geeYJMWB(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=7)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         #only need to load this once for now.
         self.gee_transition_model = r_utils.load_transitions(f"SF_12/gee_yj/SF_12_GEE_YJ", self.rpy2_modules, path=self.transition_dir)
@@ -492,7 +494,8 @@ class lmmYJMWB(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=7)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         #only need to load this once for now.
         #self.gee_transition_model = r_utils.load_transitions(f"SF_12/lmm/SF_12_LMM", self.rpy2_modules, path=self.transition_dir)
@@ -616,7 +619,8 @@ class lmmDiffMWB(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=7)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         #only need to load this once for now.
         #self.gee_transition_model = r_utils.load_transitions(f"SF_12/gee_yj/SF_12_GEE_YJ", self.rpy2_modules, path=self.transition_dir)

--- a/minos/modules/mortality.py
+++ b/minos/modules/mortality.py
@@ -37,6 +37,9 @@ class Mortality(Base):
                 The initiated vivarium simulation object with anything needed to run the module.
                 E.g. rate tables.
         """
+        # Must call parent method as overridden here; ensures priority set correctly
+        super().pre_setup(config, simulation)
+
         # Define path to mortality rate data.
         config.update({
             'path_to_mortality_file': f"{config.persistent_data_dir}/{config.mortality_file}"
@@ -98,7 +101,8 @@ class Mortality(Base):
         # Add an event every simulation time_step increment to see if anyone dies.
         # Priority 1/10 so simulants make this transition first.
         # No point becoming depressed if you're dead.
-        builder.event.register_listener('time_step', self.on_time_step, priority=1)
+        # builder.event.register_listener('time_step', self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         """  Initiate columns for mortality when new simulants are added.

--- a/minos/modules/neighbourhood.py
+++ b/minos/modules/neighbourhood.py
@@ -67,7 +67,8 @@ class Neighbourhood(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.

--- a/minos/modules/nutrition.py
+++ b/minos/modules/nutrition.py
@@ -66,7 +66,8 @@ class Nutrition(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.
@@ -183,7 +184,8 @@ class lmmYJNutrition(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         # just load this once.
         self.gee_transition_model = r_utils.load_transitions(f"nutrition_quality/lmm/nutrition_quality_new_LMM", self.rpy2Modules,
@@ -310,7 +312,8 @@ class lmmDiffNutrition(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
         # just load this once.
         self.gee_transition_model = r_utils.load_transitions(f"nutrition_quality/lmm_diff/nutrition_quality_LMM_DIFF", self.rpy2Modules,

--- a/minos/modules/replenishment.py
+++ b/minos/modules/replenishment.py
@@ -121,7 +121,8 @@ class Replenishment(Base):
         builder.population.initializes_simulants(self.on_initialize_simulants,
                                                  creates_columns=view_columns)
         # Register ageing, updating time and replenishment events on time_step.
-        builder.event.register_listener('time_step', self.on_time_step, priority=0)
+        # builder.event.register_listener('time_step', self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         """ function for loading new waves of simulants into the population from US data.
@@ -338,7 +339,8 @@ class NoReplenishment(Base):
         # Register ageing, updating time and replenishment events on time_step.
         #builder.event.register_listener('time_step', self.age_simulants)
         #builder.event.register_listener('time_step', self.update_time)
-        builder.event.register_listener('time_step', self.on_time_step, priority=0)
+        # builder.event.register_listener('time_step', self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         """ function for loading new waves of simulants into the population from US data.

--- a/minos/modules/replenishment_nowcast.py
+++ b/minos/modules/replenishment_nowcast.py
@@ -94,8 +94,8 @@ class ReplenishmentNowcast(Base):
         # Register ageing, updating time and replenishment events on time_step.
         builder.event.register_listener('time_step', self.age_simulants)
         #builder.event.register_listener('time_step', self.update_time)
-        builder.event.register_listener('time_step', self.on_time_step, priority=0)
-
+        # builder.event.register_listener('time_step', self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         """ function for loading new waves of simulants into the population from US data.

--- a/minos/modules/replenishment_scotland.py
+++ b/minos/modules/replenishment_scotland.py
@@ -97,7 +97,8 @@ class ReplenishmentScotland(Base):
         # Register ageing, updating time and replenishment events on time_step.
         builder.event.register_listener('time_step', self.age_simulants)
         #builder.event.register_listener('time_step', self.update_time)
-        builder.event.register_listener('time_step', self.on_time_step, priority=0)
+        # builder.event.register_listener('time_step', self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_initialize_simulants(self, pop_data):
         """ function for loading new waves of simulants into the population from US data.

--- a/minos/modules/tobacco.py
+++ b/minos/modules/tobacco.py
@@ -77,7 +77,8 @@ class Tobacco(Base):
 
         # Declare events in the module. At what times do individuals transition states from this module. E.g. when does
         # individual graduate in an education module.
-        builder.event.register_listener("time_step", self.on_time_step, priority=6)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=self.priority)
+        super().setup(builder)
 
     def on_time_step(self, event):
         """Produces new children and updates parent status on time steps.


### PR DESCRIPTION
- Modified base module to avoid having to add lots of new code to every other module.
- Module priorities now set once everywhere in `RunPipeline.get_priorities` and passed to simulation as data, which is then grabbed by each module at `setup`.
- This all assumes priorities are determined by the `priority` attribute and not by the order in which they're passed to the simulation.
- That means `validate_components` and `validate_and_sort_components` are redundant, so have been deleted.
- Default priority is currently 10, i.e. run last if priority not found in dict.
- Process for adding new modules is: (1) Add to `RunPipeline.components_map` (or whichever map is appropriate), define priority in `get_priorities`, then (3) ensure module calls `super().setup(builder)` if it overrides `base_module.setup`.